### PR TITLE
Turn adaptors into classes

### DIFF
--- a/src/bitbucket-pr.coffee
+++ b/src/bitbucket-pr.coffee
@@ -13,8 +13,6 @@
 
 DEFAULT_ROOM = process.env.HUBOT_BITBUCKET_PULLREQUEST_ROOM
 
-# Set default actions to announce
-
 getEnvAnnounceOptions = ->
   # Replace announce options if set in the environment
   if process.env.HUBOT_BITBUCKET_PULLREQUEST_ANNOUNCE

--- a/src/bitbucket-pr.coffee
+++ b/src/bitbucket-pr.coffee
@@ -14,17 +14,16 @@
 DEFAULT_ROOM = process.env.HUBOT_BITBUCKET_PULLREQUEST_ROOM
 
 # Set default actions to announce
-DEFAULT_ANNOUNCE_OPTIONS = [
-  'created', 'updated', 'declined', 'merged',
-  'comment_created', 'approve', 'unapprove'
-]
 
 getEnvAnnounceOptions = ->
   # Replace announce options if set in the environment
   if process.env.HUBOT_BITBUCKET_PULLREQUEST_ANNOUNCE
     process.env.HUBOT_BITBUCKET_PULLREQUEST_ANNOUNCE.replace(/[^a-z\,]+/, '').split(',')
+  # Fall back to default actions to announce
+  else
+    ['created', 'updated', 'declined', 'merged', 'comment_created', 'approve', 'unapprove']
 
-ANNOUNCE_OPTIONS = getEnvAnnounceOptions() ? DEFAULT_ANNOUNCE_OPTIONS
+ANNOUNCE_OPTIONS = getEnvAnnounceOptions()
 
 ENCOURAGEMENTS = [
   ':thumbsup:', 'That was a nice thing you did.', 'Boomtown',

--- a/src/bitbucket-pr.coffee
+++ b/src/bitbucket-pr.coffee
@@ -57,7 +57,7 @@ class PullRequestEvent
     super branch#{@reason}"
 
   getMessage: ->
-    msg = switch
+    switch
       # PR created
       when @type is 'pullrequest:created' && 'created' in ANNOUNCE_OPTIONS
         @robot.logger.debug "Pull request created"
@@ -192,13 +192,13 @@ class SlackPullRequestEvent extends PullRequestEvent
       ]
 
   pullRequestDeclined: ->
-    content = @branchAction('Declined', @RED)
+    @branchAction('Declined', @RED)
 
   pullRequestMerged: ->
-    content = @branchAction('Merged', @GREEN)
+    @branchAction('Merged', @GREEN)
 
   pullRequestUpdated: ->
-    content = @branchAction('Updated', @PURPLE)
+    @branchAction('Updated', @PURPLE)
 
   pullRequestApproved: ->
     content =

--- a/src/bitbucket-pr.coffee
+++ b/src/bitbucket-pr.coffee
@@ -26,6 +26,14 @@ getEnvAnnounceOptions = ->
 
 ANNOUNCE_OPTIONS = getEnvAnnounceOptions() ? DEFAULT_ANNOUNCE_OPTIONS
 
+ENCOURAGEMENTS = [
+  ':thumbsup:', 'That was a nice thing you did.', 'Boomtown',
+  'BOOM', 'Finally.', 'And another request bites the dust.'
+]
+
+encourageMe = ->
+  ENCOURAGEMENTS[Math.floor(Math.random() * ENCOURAGEMENTS.length)]
+
 module.exports = (robot) ->
   robot.router.post '/hubot/bitbucket-pr', (req, res) ->
     resp = req.body
@@ -117,12 +125,10 @@ module.exports = (robot) ->
 
       # Approved
       if type is 'pullrequest:approved' && ('approve' in ANNOUNCE_OPTIONS)
-        encourage_array = [':thumbsup:', 'That was a nice thing you did.', 'Boomtown', 'BOOM', 'Finally.', 'And another request bites the dust.']
-        encourage_me = encourage_array[Math.floor(Math.random()*encourage_array.length)];
         content =
           text: "Pull Request Approved"
-          fallback: "A pull request on `#{cached_vars.repo_name}` has been approved by #{cached_vars.actor}\n#{encourage_me}"
-          pretext: encourage_me
+          fallback: "A pull request on `#{cached_vars.repo_name}` has been approved by #{cached_vars.actor}\n#{encourageMe()}"
+          pretext: encourageMe()
           color: green
           mrkdwn_in: ["text", "title", "fallback", "fields"]
           fields: [
@@ -194,9 +200,7 @@ module.exports = (robot) ->
       # Approved
       if type is 'pullrequest:approved' && ('approve' in ANNOUNCE_OPTIONS)
         msg = "A pull request on `#{cached_vars.repo_name}` has been approved by #{cached_vars.actor}"
-        encourage_array = [':thumbsup:', 'That was a nice thing you did.', 'Boomtown', 'BOOM', 'Finally.', 'And another request bites the dust.']
-        encourage_me = encourage_array[Math.floor(Math.random()*encourage_array.length)];
-        msg += "\n#{encourage_me}"
+        msg += "\n#{encourageMe()}"
         msg += "\n#{cached_vars.pr_link}"
 
       # Unapproved

--- a/src/bitbucket-pr.coffee
+++ b/src/bitbucket-pr.coffee
@@ -161,10 +161,7 @@ class SlackPullRequestEvent extends PullRequestEvent
         }
         {
           title: @repo_name
-          value: """
-            Merge to #{@destination_branch}
-            #{@pr_link}
-          """
+          value: "Merge to #{@destination_branch}\n#{@pr_link}"
           short: true
         }
       ]

--- a/src/bitbucket-pr.coffee
+++ b/src/bitbucket-pr.coffee
@@ -52,7 +52,7 @@ class PullRequestEvent
     else
       'no one in particular'
 
-  @branchAction: (action_name, action_desc) ->
+  branchAction: (action_name, action_desc) ->
     "#{@actor} *#{action_name}* pull request \"#{@title},\" #{action_desc}
     `#{@source_branch}` and `#{@destination_branch}` into a `#{@repo_name}`
     super branch#{@reason}"
@@ -126,7 +126,7 @@ class SlackPullRequestEvent extends PullRequestEvent
   PURPLE: '#AA82E5'
   ORANGE: '#F1A56F'
 
-  @branchAction: (action_name, color) ->
+  branchAction: (action_name, color) ->
     fields = []
     fields.push
       title: @title

--- a/src/bitbucket-pr.coffee
+++ b/src/bitbucket-pr.coffee
@@ -39,7 +39,10 @@ class PullRequestEvent
     @destination_branch = @resp.pullrequest.destination.branch.name
     @repo_name = @resp.repository.name
     @pr_link = @resp.pullrequest.links.html.href
-    @reason = if @resp.reason isnt '' then ":\n\"#{@resp.pullrequest.reason}\"" else "."
+    @reason = "."
+    if @resp.reason isnt ''
+      if @resp.pullrequest.reason isnt ''
+        @reason = ":\n\"#{@resp.pullrequest.reason}\""
 
   getReviewers: ->
     if @resp.pullrequest.reviewers.length > 0

--- a/src/bitbucket-pr.coffee
+++ b/src/bitbucket-pr.coffee
@@ -52,7 +52,7 @@ class PullRequestEvent
     else
       'no one in particular'
 
-  branchAction: (action_name, action_desc) ->
+  @branchAction: (action_name, action_desc) ->
     "#{@actor} *#{action_name}* pull request \"#{@title},\" #{action_desc}
     `#{@source_branch}` and `#{@destination_branch}` into a `#{@repo_name}`
     super branch#{@reason}"
@@ -104,13 +104,13 @@ class PullRequestEvent
     \"#{@resp.comment.content.raw}\"\n#{@resp.comment.links.html.href}"
 
   pullRequestDeclined: ->
-    branch_action('declined', 'thwarting the attempted merge of') + "\n#{@pr_link}"
+    @branchAction('declined', 'thwarting the attempted merge of') + "\n#{@pr_link}"
 
   pullRequestMerged: ->
-    branch_action('merged', 'joining in sweet harmony')
+    @branchAction('merged', 'joining in sweet harmony')
 
   pullRequestUpdated: ->
-    branch_action('updated', 'clarifying why it is necessary to merge') + "\n#{@pr_link}"
+    @branchAction('updated', 'clarifying why it is necessary to merge') + "\n#{@pr_link}"
 
   pullRequestApproved: ->
     "A pull request on `#{@repo_name}` has been approved by #{@actor}
@@ -126,7 +126,7 @@ class SlackPullRequestEvent extends PullRequestEvent
   PURPLE: '#AA82E5'
   ORANGE: '#F1A56F'
 
-  branchAction: (action_name, color) ->
+  @branchAction: (action_name, color) ->
     fields = []
     fields.push
       title: @title
@@ -193,13 +193,13 @@ class SlackPullRequestEvent extends PullRequestEvent
       ]
 
   pullRequestDeclined: ->
-    content = branch_action('Declined', @RED)
+    content = @branchAction('Declined', @RED)
 
   pullRequestMerged: ->
-    content = branch_action('Merged', @GREEN)
+    content = @branchAction('Merged', @GREEN)
 
   pullRequestUpdated: ->
-    content = branch_action('Updated', @PURPLE)
+    content = @branchAction('Updated', @PURPLE)
 
   pullRequestApproved: ->
     content =

--- a/src/bitbucket-pr.coffee
+++ b/src/bitbucket-pr.coffee
@@ -60,37 +60,37 @@ class PullRequestEvent
   getMessage: ->
     msg = switch
       # PR created
-      when type is 'pullrequest:created' && 'created' in ANNOUNCE_OPTIONS
+      when @type is 'pullrequest:created' && 'created' in ANNOUNCE_OPTIONS
         @robot.logger.debug "Pull request created"
         @pullRequestCreated()
 
       # Comment created
-      when type is 'pullrequest:comment_created' && 'comment_created' in ANNOUNCE_OPTIONS
+      when @type is 'pullrequest:comment_created' && 'comment_created' in ANNOUNCE_OPTIONS
         @robot.logger.debug "Pull request comment created"
         @pullRequestCommentCreated()
 
       # Declined
-      when type is 'pullrequest:rejected' && 'declined' in ANNOUNCE_OPTIONS
+      when @type is 'pullrequest:rejected' && 'declined' in ANNOUNCE_OPTIONS
         @robot.logger.debug "Pull request rejected"
         @pullRequestDeclined()
 
       # Merged
-      when type is 'pullrequest:fulfilled' && 'merged' in ANNOUNCE_OPTIONS
+      when @type is 'pullrequest:fulfilled' && 'merged' in ANNOUNCE_OPTIONS
         @robot.logger.debug "Pull request merged"
         @pullRequestMerged()
 
       # Updated
-      when type is 'pullrequest:updated' && 'updated' in ANNOUNCE_OPTIONS
+      when @type is 'pullrequest:updated' && 'updated' in ANNOUNCE_OPTIONS
         @robot.logger.debug "Pull request updated"
         @pullRequestUpdated()
 
       # Approved
-      when type is 'pullrequest:approved' && 'approve' in ANNOUNCE_OPTIONS
+      when @type is 'pullrequest:approved' && 'approve' in ANNOUNCE_OPTIONS
         @robot.logger.debug "Pull request approved"
         @pullRequestApproved()
 
       # Unapproved
-      when type is 'pullrequest:unapproved' && 'unapprove' in ANNOUNCE_OPTIONS
+      when @type is 'pullrequest:unapproved' && 'unapprove' in ANNOUNCE_OPTIONS
         @robot.logger.debug "Pull request unapproved"
         @pullRequestUnapproved()
 

--- a/src/bitbucket-pr.coffee
+++ b/src/bitbucket-pr.coffee
@@ -1,10 +1,6 @@
 # Description:
 #   Holler whenever anything happens around a Bitbucket pull request
 #
-# Dependencies:
-#   "url": ""
-#   "querystring": ""
-#
 # Configuration:
 #   Set up a Bitbucket Pull Request hook with the URL
 #   {your_hubot_base_url}/hubot/bitbucket-pr. Check all boxes on prompt.
@@ -15,12 +11,11 @@
 # Author:
 #   tshedor
 
-url = require('url')
-querystring = require('querystring')
+DEFAULT_ROOM = process.env.HUBOT_BITBUCKET_PULLREQUEST_ROOM
+
 
 module.exports = (robot) ->
   robot.router.post '/hubot/bitbucket-pr', (req, res) ->
-    query = querystring.parse(url.parse(req.url).query)
 
     # Set default actions to announce
     announce_options = ['created', 'updated', 'declined', 'merged', 'comment_created', 'approve', 'unapprove']
@@ -29,8 +24,6 @@ module.exports = (robot) ->
     if process.env.HUBOT_BITBUCKET_PULLREQUEST_ANNOUNCE
       announce_options = process.env.HUBOT_BITBUCKET_PULLREQUEST_ANNOUNCE.replace(/[^a-z\,]+/, '').split(',')
 
-    # Fallback to default Pull request room
-    room = if query.room then query.room else process.env.HUBOT_BITBUCKET_PULLREQUEST_ROOM
 
     resp = req.body
 
@@ -48,6 +41,8 @@ module.exports = (robot) ->
       repo_name: resp.repository.name
       pr_link: resp.pullrequest.links.html.href
     }
+    # Fallback to default Pull request room
+    room = req.query.room ? DEFAULT_ROOM
 
     # Slack special formatting
     if robot.adapterName is 'slack'


### PR DESCRIPTION
This turns the two adaptors (Slack and 'everything else') into two classes and reduces some duplication while doing so - 'everything else' being the base class called ``PullRequestEvent`` which Slack then subclasses.

This should allow fairly easy adding of other adaptors later, should they wish to. Or to easily subclass an existing adaptor to change the output style, e.g. the Slack adaptor.